### PR TITLE
app: show values from all layers in the tooltip on hover

### DIFF
--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -120,7 +120,7 @@ export const TooltipInfo = React.memo(() => {
           {detail.label.tags && detail.label.tags.length > 0 && (
             <TagInfo key={"tags"} tags={detail.label?.tags} />
           )}
-          <AllLayerInfo key={"attrs"} detail={detail} />
+          <AllOverlayInfo key={"attrs"} detail={detail} />
         </TooltipDiv>,
         document.body
       )
@@ -269,17 +269,19 @@ const PolylineInfo = ({ detail }) => {
   );
 };
 
-function AllLayerInfo(props: {
-  detail: { color: string; target: any; layers: any[] };
+/** Component that lists values from all overlays of the hovered item */
+function AllOverlayInfo(props: {
+  detail: { color: string; target: any; overlayDetails: any[] };
 }): JSX.Element {
   const { detail } = props;
+  const { overlayDetails = [] } = detail;
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      {detail.layers.map((layer) => (
+      {overlayDetails.map((overlay) => (
         <ContentItem
-          key={`pixel-value-${layer.field}`}
-          name={layer.field}
-          value={layer.target}
+          key={`pixel-value-${overlay.field}`}
+          name={overlay.field}
+          value={overlay.target}
         />
       ))}
     </AttrBlock>

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -25,25 +25,26 @@ export const dispatchTooltipEvent = <State extends BaseState>(
       return;
     }
 
-    // Point details for all overlays
-    let layers = !nullify
+    // Get the point info from all overlays
+    let overlayDetails = !nullify
       ? overlays
           .filter((overlay) => overlay.containsPoint(state))
           .map((overlay) => overlay.getPointInfo(state))
       : [];
 
-    // @ts-ignore
-    if (state.frameNumber) {
-      // @ts-ignore
-      layers.forEach((detail) => (detail.frameNumber = state.frameNumber));
+    if ("frameNumber" in state) {
+      overlayDetails.forEach(
+        (detail) => (detail.frameNumber = state.frameNumber)
+      );
     }
     dispatchEvent(
       "tooltip",
-      layers.length > 0
+      overlayDetails.length > 0
         ? {
-            ...layers[0], // for compatibility
+            // Include the top-most overlay in the event for compatibility
+            ...overlayDetails[0],
             coordinates: state.cursorCoordinates,
-            layers,
+            overlayDetails,
           }
         : null
     );


### PR DESCRIPTION
* Show values from all layers in the tooltip
* Remove the "id" thing
* Use `.toPrecision` instead of `.toFixed` when displaying values

<img width="773" alt="nxplayer bin_2023-01-11-08-59-56-514" src="https://user-images.githubusercontent.com/3599407/211881757-1e05f9ea-a988-4053-abfa-fd0517bc7de4.png">

<details>
  <summary>How the tooltip looked before</summary>

<img width="759" alt="nxplayer bin_2023-01-09-12-14-59-669" src="https://user-images.githubusercontent.com/3599407/211881964-5b1d6485-2562-48be-a929-64eb72c09fe1.png">

</details>