### PR TITLE
app: fix segmentation labels showing int class instead of class name

### DIFF
--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -274,16 +274,24 @@ function AllOverlayInfo(props: {
   detail: { color: string; target: any; overlayDetails: any[] };
 }): JSX.Element {
   const { detail } = props;
+  const getTarget = useRecoilValue(fos.getTarget);
   const { overlayDetails = [] } = detail;
+
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      {overlayDetails.map((overlay) => (
-        <ContentItem
-          key={`pixel-value-${overlay.field}`}
-          name={overlay.field}
-          value={overlay.target}
-        />
-      ))}
+      {overlayDetails.map((overlay) => {
+        const value =
+          overlay.type === "Segmentation"
+            ? getTarget(overlay.field, overlay.target)
+            : overlay.target;
+        return (
+          <ContentItem
+            key={`pixel-value-${overlay.field}`}
+            name={overlay.field}
+            value={value}
+          />
+        );
+      })}
     </AttrBlock>
   );
 }


### PR DESCRIPTION
I forgot to test segmentations, they were showing just the integer value.

<img width="245" alt="nxplayer bin_2023-01-17-13-25-35-100" src="https://user-images.githubusercontent.com/3599407/213016076-b98ea443-b0bc-43c2-bdfa-4b67033b54fe.png">
