### PR TITLE
app: make alpha=1 and no selected labels the default

### DIFF
--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -147,7 +147,7 @@ export const viewCounter = atom({
   default: 0,
 });
 
-export const DEFAULT_ALPHA = 0.7;
+export const DEFAULT_ALPHA = 1.0;
 
 export const alpha = atomFamily<number, boolean>({
   key: "alpha",

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -356,7 +356,7 @@ export const labelPath = selectorFamily<string, string>({
 
 export const _activeFields = atomFamily<string[], { modal: boolean }>({
   key: "_activeFields",
-  default: null,
+  default: [],
 });
 
 export const activeFields = selectorFamily<string[], { modal: boolean }>({


### PR DESCRIPTION
I debated making these configurable in python via `session.config`, but these are tiny enough changes that if they are available in the config in the future, we can just revert these changes.

<img width="701" alt="nxplayer bin_2023-01-17-14-36-39-577" src="https://user-images.githubusercontent.com/3599407/213027441-b7cdf4f9-9f08-4021-8e55-755500006537.png">

https://app.asana.com/0/1203288718560208/1203760646166079/f