### PR TITLE
app: fix circular dependency

### DIFF
--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -2,6 +2,7 @@
  * Copyright 2017-2022, Voxel51, Inc.
  */
 import {
+  clamp,
   get32BitColor,
   getColor,
   getRGBA,
@@ -9,7 +10,7 @@ import {
 } from "@fiftyone/utilities";
 import { ARRAY_TYPES, NumpyResult, TypedArray } from "../numpy";
 import { BaseState, Coordinates } from "../state";
-import { clamp, isFloatArray } from "../util";
+import { isFloatArray } from "../util";
 import {
   BaseLabel,
   CONTAINS,

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -519,7 +519,3 @@ export const getMimeType = (sample: any) => {
 
 export const isFloatArray = (arr) =>
   arr instanceof Float32Array || arr instanceof Float64Array;
-
-export function clamp(min: number, max: number, value: number) {
-  return Math.min(Math.max(value, min), max);
-}

--- a/app/packages/looker/src/worker.ts
+++ b/app/packages/looker/src/worker.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  clamp,
   LABEL_LIST,
   VALID_LABEL_TYPES,
   getFetchFunction,
@@ -13,7 +14,6 @@ import {
 import { CHUNK_SIZE } from "./constants";
 import { ARRAY_TYPES, deserialize } from "./numpy";
 import { Coloring, FrameChunk } from "./state";
-import { clamp } from "./util";
 
 interface ResolveColor {
   key: string | number;

--- a/app/packages/utilities/src/color.ts
+++ b/app/packages/utilities/src/color.ts
@@ -202,3 +202,7 @@ export const getColor = (
 ) => {
   return createColorGenerator(pool, seed)(fieldOrValue);
 };
+
+export function clamp(min: number, max: number, value: number) {
+  return Math.min(Math.max(value, min), max);
+}


### PR DESCRIPTION
Move the `clamp` util function to `packages/utilities/color.ts` to eliminate a circular dependency that causes the build to OOM.