### PR TITLE
app: enable sourcemaps in production build

### DIFF
--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -6,6 +6,9 @@ import relay from "vite-plugin-relay";
 export default defineConfig(({ mode }) => {
   return {
     base: mode === "desktop" ? "" : "/",
+    build: {
+      sourcemap: true
+    },
     plugins: [
       reactRefresh({
         parserPlugins: ["classProperties", "classPrivateProperties"],


### PR DESCRIPTION
This would make it easier to debug any crashes in the docker image without having to reproduce in dev.

https://app.asana.com/0/1203288718560208/1203665779135467/f