### PR TITLE
server, app: add grid_thumbnail_fields to graphql

### DIFF
--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -29,6 +29,7 @@ const DatasetQuery = graphql`
           paths
           name
         }
+        gridThumbnailFields
       }
       sampleFields {
         ftype
@@ -102,6 +103,7 @@ const DatasetQuery = graphql`
           paths
         }
         sidebarMode
+        gridThumbnailFields
       }
       info
     }

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a2f8d4a86d8e3c6654edba23aa04eab9>>
+ * @generated SignedSource<<7b381c50a6a746c1c62f2054176fef9c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type DatasetQuery$data = {
   readonly dataset: {
     readonly appConfig: {
       readonly gridMediaField: string | null;
+      readonly gridThumbnailFields: object | null;
       readonly mediaFields: ReadonlyArray<string>;
       readonly plugins: object | null;
       readonly sidebarGroups: ReadonlyArray<{
@@ -357,6 +358,13 @@ v17 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "gridThumbnailFields",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "sidebarMode",
             "storageKey": null
           }
@@ -596,16 +604,16 @@ return {
     "selections": (v17/*: any*/)
   },
   "params": {
-    "cacheID": "3226eb44467b4f22960c95abc34dab11",
+    "cacheID": "3fb49422cab6144e41e2c7915f48fdb0",
     "id": null,
     "metadata": {},
     "name": "DatasetQuery",
     "operationKind": "query",
-    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      sidebarMode\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    info\n  }\n}\n"
+    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      gridThumbnailFields\n      sidebarMode\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    info\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cb693b696a0015821db22d1c36900251";
+(node as any).hash = "cf9241bdb7344bc90d22665114d8d4ba";
 
 export default node;

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -90,6 +90,7 @@ export namespace State {
     plugins?: PluginConfig;
     sidebarGroups?: SidebarGroup[];
     sidebarMode?: "all" | "best" | "fast";
+    gridThumbnailFields?: { [field: string]: string };
   }
   export interface Dataset {
     id: string;

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -142,6 +142,7 @@ type DatasetAppConfig {
   sidebarMode: SidebarMode
   modalMediaField: String
   gridMediaField: String
+  gridThumbnailFields: JSON
 }
 
 type DatasetStrConnection {

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -315,6 +315,9 @@ class DatasetAppConfig(EmbeddedDocument):
             -   ``"point-cloud"``: See the
                 :ref:`3D visualizer docs <3d-visualizer-config>` for supported
                 options
+        grid_thumbnail_fields ({}): an optional dict mapping sample fields to
+            sample thumbnail fields (where the thumbnail fields contain string
+            paths to the thumbnail images on disk)
     """
 
     # strict=False lets this class ignore unknown fields from other versions

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -328,6 +328,7 @@ class DatasetAppConfig(EmbeddedDocument):
         EmbeddedDocumentField(SidebarGroupDocument), default=None
     )
     plugins = DictField()
+    grid_thumbnail_fields = DictField()
 
     @staticmethod
     def default_sidebar_groups(sample_collection):

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -140,6 +140,7 @@ class DatasetAppConfig:
     sidebar_mode: t.Optional[SidebarMode]
     modal_media_field: t.Optional[str] = gql.field(default="filepath")
     grid_media_field: t.Optional[str] = "filepath"
+    grid_thumbnail_fields: t.Optional[JSON]
 
 
 @gql.type


### PR DESCRIPTION
Add `dataset.app_config.grid_thumbnail_fields` to graphql so that it is available in the app after adding it via Jupyter.

`schema.graphql` and `DatasetQuery.graphql.ts` were generated by running `yarn run gen:schema` in the `app/` folder. (Generated based on `fiftyone/core/odm/dataset.py` and `fiftyone/server/query.py`)

![2023-02-07_10-08-08](https://user-images.githubusercontent.com/3599407/217329630-29ad2bda-fda3-4d65-9e22-74efbe22e252.png)

FiftyOne thumbnail PRs:
* add option to generate thumbnails for FiftyOne
* update example script to generate thumbnails
* **add custom grid_thumbnail_fields field to server backend** (#9)
* add custom thumbnails_only param to server route (#10)
* add custom sample_id param to server route (#11)
* show thumbnails in the grid view of the app (#12)
* lazy load the full sample when opened in a modal

https://app.asana.com/0/0/1203821999397249/f