### PR TITLE
server: add thumbnails_only option to the /samples query

### DIFF
--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -25,6 +25,7 @@ class Samples(HTTPEndpoint):
         page_length = data.get("page_length", 20)
         slice = data.get("slice", None)
         extended = data.get("extended", None)
+        thumbnails_only = data.get("thumbnails_only", False)
 
         results = await paginate_samples(
             dataset,
@@ -34,6 +35,7 @@ class Samples(HTTPEndpoint):
             (page - 1) * page_length - 1,
             sample_filter=SampleFilter(group=GroupElementFilter(slice=slice)),
             extended_stages=extended,
+            thumbnails_only=thumbnails_only,
         )
 
         return {


### PR DESCRIPTION
When opening the app, a `/samples` request returns all samples in the dataset, including all the heatmap and semseg data. The `thumbnails_only` option will strip any data with an associated thumbnail (from the `dataset.app_config.grid_media_thumbnails` mapping).

**Before**, 16MB response, dev tools won't even cache and show the response preview:
![2023-02-07_14-47-49 cropped](https://user-images.githubusercontent.com/3599407/217384624-45a3496d-ae05-46bc-872b-eb61fcfaa255.png)

**After**, 17KB response, with `thumbnails_only: true`:
![2023-02-07_14-42-34](https://user-images.githubusercontent.com/3599407/217384706-f25bdbf2-5321-4d6a-852b-8e11ba1d577e.png)

FiftyOne thumbnail PRs:
* add option to generate thumbnails for FiftyOne
* update example script to generate thumbnails
* add custom grid_thumbnail_fields field to server backend (#9)
* **add custom thumbnails_only param to /samples server route** (#10)
* add custom sample_id param to server route (#11)
* show thumbnails in the grid view of the app (#12)
* lazy load the full sample when opened in a modal

https://app.asana.com/0/0/1203821999397249/f