### PR TITLE
server: add sample_id option to the /samples query

### DIFF
--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -24,8 +24,15 @@ class Samples(HTTPEndpoint):
         page = data.get("page", 1)
         page_length = data.get("page_length", 20)
         slice = data.get("slice", None)
+        sample_id = data.get("sample_id", None)
         extended = data.get("extended", None)
         thumbnails_only = data.get("thumbnails_only", False)
+
+        sample_filter = (
+            SampleFilter(id=sample_id)
+            if sample_id
+            else SampleFilter(group=GroupElementFilter(slice=slice))
+        )
 
         results = await paginate_samples(
             dataset,
@@ -33,7 +40,7 @@ class Samples(HTTPEndpoint):
             filters,
             page_length,
             (page - 1) * page_length - 1,
-            sample_filter=SampleFilter(group=GroupElementFilter(slice=slice)),
+            sample_filter=sample_filter,
             extended_stages=extended,
             thumbnails_only=thumbnails_only,
         )


### PR DESCRIPTION
This will be used when clicking on a sample from the grid. A second request will retrieve the full sample field data for just that sample.

FiftyOne thumbnail PRs:
* add option to generate thumbnails for FiftyOne
* update example script to generate thumbnails
* add custom grid_thumbnail_fields field to server backend (#9)
* add custom thumbnails_only param to /samples server route (#10)
* **add custom sample_id param to server route** (#11)
* show thumbnails in the grid view of the app (#12)
* lazy load the full sample when opened in a modal

https://app.asana.com/0/0/1203821999397249/f