### PR TITLE
app: show thumbnails in grid when available

### DIFF
--- a/app/packages/core/src/components/Grid/recoil.ts
+++ b/app/packages/core/src/components/Grid/recoil.ts
@@ -44,7 +44,7 @@ export const pageParameters = selectorFamily<PageParameters, boolean>({
         zoom: get(fos.isPatchesView) && get(fos.cropToContent(modal)),
         slice: get(groupSlice(false)),
         // TODO: change this to !modal when lazy loading samples on click is
-        // supported
+        // implemented
         thumbnails_only: false,
       };
     },

--- a/app/packages/core/src/components/Grid/recoil.ts
+++ b/app/packages/core/src/components/Grid/recoil.ts
@@ -43,6 +43,8 @@ export const pageParameters = selectorFamily<PageParameters, boolean>({
         extended: get(fos.extendedStages),
         zoom: get(fos.isPatchesView) && get(fos.cropToContent(modal)),
         slice: get(groupSlice(false)),
+        // TODO: change this to !modal when lazy loading samples on click is
+        // supported
         thumbnails_only: false,
       };
     },

--- a/app/packages/core/src/components/Grid/recoil.ts
+++ b/app/packages/core/src/components/Grid/recoil.ts
@@ -28,6 +28,7 @@ export interface PageParameters {
   dataset: string;
   view: fos.State.Stage[];
   zoom: boolean;
+  thumbnails_only: boolean;
 }
 
 export const pageParameters = selectorFamily<PageParameters, boolean>({
@@ -42,6 +43,7 @@ export const pageParameters = selectorFamily<PageParameters, boolean>({
         extended: get(fos.extendedStages),
         zoom: get(fos.isPatchesView) && get(fos.cropToContent(modal)),
         slice: get(groupSlice(false)),
+        thumbnails_only: false,
       };
     },
 });

--- a/app/packages/core/src/components/Grid/useExpandSample.ts
+++ b/app/packages/core/src/components/Grid/useExpandSample.ts
@@ -1,6 +1,6 @@
-import { FlashlightConfig } from "@fiftyone/flashlight";
 import { useCallback } from "react";
 
+import { FlashlightConfig } from "@fiftyone/flashlight";
 import * as fos from "@fiftyone/state";
 
 export default <T extends fos.Lookers>(store: fos.LookerStore<T>) => {

--- a/app/packages/core/src/components/Grid/useExpandSample.ts
+++ b/app/packages/core/src/components/Grid/useExpandSample.ts
@@ -1,6 +1,6 @@
+import { FlashlightConfig } from "@fiftyone/flashlight";
 import { useCallback } from "react";
 
-import { FlashlightConfig } from "@fiftyone/flashlight";
 import * as fos from "@fiftyone/state";
 
 export default <T extends fos.Lookers>(store: fos.LookerStore<T>) => {

--- a/app/packages/core/src/components/Grid/usePage.ts
+++ b/app/packages/core/src/components/Grid/usePage.ts
@@ -41,6 +41,8 @@ const usePage = (
                 urls: Object.fromEntries(
                   result.urls.map(({ field, url }) => [field, url])
                 ),
+                // Mark whether or not this sample only has thumbnails
+                thumbnailsOnly: params.thumbnails_only,
               };
 
               store.samples.set(result.sample._id, data);

--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -202,7 +202,7 @@ export abstract class Looker<
   }
 
   loadOverlays(sample: Sample): void {
-    this.sampleOverlays = loadOverlays(sample);
+    this.sampleOverlays = loadOverlays(this.state, sample);
   }
 
   pluckOverlays(state: Readonly<State>): Overlay<State>[] {
@@ -932,7 +932,7 @@ const { acquireReader, addFrame } = (() => {
           Object.entries(frameSample).map(([k, v]) => ["frames." + k, v])
         );
 
-        const overlays = loadOverlays(prefixedFrameSample);
+        const overlays = loadOverlays(null, prefixedFrameSample);
         overlays.forEach((overlay) => {
           streamSize += overlay.getSizeBytes();
         });
@@ -1143,6 +1143,7 @@ export class VideoLooker extends Looker<VideoState, VideoSample> {
 
   loadOverlays(sample: VideoSample) {
     this.sampleOverlays = loadOverlays(
+      this.state,
       Object.fromEntries(
         Object.entries(sample).filter(([fieldName]) => fieldName !== "frames")
       ),
@@ -1154,6 +1155,7 @@ export class VideoLooker extends Looker<VideoState, VideoSample> {
       : [{ frame_number: 1 }];
     const providedFrameOverlays = providedFrames.map((frameSample) =>
       loadOverlays(
+        this.state,
         Object.fromEntries(
           Object.entries(frameSample).map(([k, v]) => ["frames." + k, v])
         )

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -74,7 +74,8 @@ export const loadOverlays = <State extends BaseState>(
     }
   }
 
-  // Include any grid thumbnails
+  // When in the grid view (`state.config.thumbnail=true`), create
+  // ThumbnailOverlays for any fields with thumbnails.
   if (state?.config.thumbnail) {
     const gridThumbnailFields =
       state?.config?.appConfig?.gridThumbnailFields ?? {};

--- a/app/packages/looker/src/overlays/thumbnail.ts
+++ b/app/packages/looker/src/overlays/thumbnail.ts
@@ -1,6 +1,3 @@
-/**
- * Copyright 2017-2022, Voxel51, Inc.
- */
 import { getFetchOrigin, getFetchPathPrefix } from "@fiftyone/utilities";
 
 import {
@@ -45,10 +42,12 @@ export default class ThumbnailOverlay<State extends BaseState>
     const [brx, bry] = t(state, 1, 1);
     const tmp = ctx.globalAlpha;
     ctx.globalAlpha = state.options.alpha;
-    console.log("ThumbnailOverlay.draw", tlx, tly, brx - tlx, bry - tly);
     ctx.drawImage(this.image, tlx, tly, brx - tlx, bry - tly);
     ctx.globalAlpha = tmp;
   }
+
+  // There is no need to support the remaining methods, as the ThumbnailOverlay
+  // won't be used in a modal, and won't need to interact.
 
   getMouseDistance(_state: Readonly<State>): number {
     return Infinity;

--- a/app/packages/looker/src/overlays/thumbnail.ts
+++ b/app/packages/looker/src/overlays/thumbnail.ts
@@ -13,6 +13,11 @@ import { t } from "./util";
 
 interface ThumbnailInfo extends BaseLabel {}
 
+/**
+ * Overlay for rendering thumbnail images by drawing directly to the canvas.
+ *
+ * This overlay is intended for the grid view only and is not interactable.
+ */
 export default class ThumbnailOverlay<State extends BaseState>
   implements Overlay<State>
 {
@@ -26,6 +31,7 @@ export default class ThumbnailOverlay<State extends BaseState>
     this.thumbnailField = thumbnailField;
     this.thumbnailPath = thumbnailPath;
 
+    // Preload the image via the `/media` route
     this.image = document.createElement("img");
     this.image.crossOrigin = "anonymous";
     this.image.src = `${getFetchOrigin()}${getFetchPathPrefix()}/media?filepath=${encodeURIComponent(
@@ -33,11 +39,10 @@ export default class ThumbnailOverlay<State extends BaseState>
     )}`;
   }
 
-  containsPoint(_state: Readonly<State>): CONTAINS {
-    return CONTAINS.NONE;
-  }
-
   draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
+    // Transform the image based on the state (derived from pan and zoom).
+    // This is not necessary for thumbnails, but it's short enough to leave in
+    // for consistency across overlays.
     const [tlx, tly] = t(state, 0, 0);
     const [brx, bry] = t(state, 1, 1);
     const tmp = ctx.globalAlpha;
@@ -47,7 +52,11 @@ export default class ThumbnailOverlay<State extends BaseState>
   }
 
   // There is no need to support the remaining methods, as the ThumbnailOverlay
-  // won't be used in a modal, and won't need to interact.
+  // won't be used in a modal, and won't need to handle any interactions.
+
+  containsPoint(_state: Readonly<State>): CONTAINS {
+    return CONTAINS.NONE;
+  }
 
   getMouseDistance(_state: Readonly<State>): number {
     return Infinity;

--- a/app/packages/looker/src/overlays/thumbnail.ts
+++ b/app/packages/looker/src/overlays/thumbnail.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2017-2022, Voxel51, Inc.
+ */
+import { getFetchOrigin, getFetchPathPrefix } from "@fiftyone/utilities";
+
+import {
+  BaseLabel,
+  CONTAINS,
+  isShown,
+  Overlay,
+  PointInfo,
+  SelectData,
+} from "./base";
+import { BaseState, Coordinates } from "../state";
+import { t } from "./util";
+
+interface ThumbnailInfo extends BaseLabel {}
+
+export default class ThumbnailOverlay<State extends BaseState>
+  implements Overlay<State>
+{
+  readonly field: string;
+  readonly thumbnailField: string;
+  readonly thumbnailPath: string;
+  private image: HTMLImageElement;
+
+  constructor(field: string, thumbnailField: string, thumbnailPath: string) {
+    this.field = field;
+    this.thumbnailField = thumbnailField;
+    this.thumbnailPath = thumbnailPath;
+
+    this.image = document.createElement("img");
+    this.image.crossOrigin = "anonymous";
+    this.image.src = `${getFetchOrigin()}${getFetchPathPrefix()}/media?filepath=${encodeURIComponent(
+      thumbnailPath
+    )}`;
+  }
+
+  containsPoint(_state: Readonly<State>): CONTAINS {
+    return CONTAINS.NONE;
+  }
+
+  draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
+    const [tlx, tly] = t(state, 0, 0);
+    const [brx, bry] = t(state, 1, 1);
+    const tmp = ctx.globalAlpha;
+    ctx.globalAlpha = state.options.alpha;
+    console.log("ThumbnailOverlay.draw", tlx, tly, brx - tlx, bry - tly);
+    ctx.drawImage(this.image, tlx, tly, brx - tlx, bry - tly);
+    ctx.globalAlpha = tmp;
+  }
+
+  getMouseDistance(_state: Readonly<State>): number {
+    return Infinity;
+  }
+
+  getPointInfo(_state: Readonly<State>): PointInfo<ThumbnailInfo> {
+    return {
+      color: "",
+      label: {
+        id: "",
+        _cls: "Thumbnail",
+        tags: [],
+      },
+      field: this.field,
+      type: "Thumbnail",
+    };
+  }
+
+  getSelectData(): SelectData {
+    return {
+      id: "",
+      field: this.field,
+    };
+  }
+
+  isSelected(_state: Readonly<State>): boolean {
+    return false;
+  }
+
+  isShown(state: Readonly<State>): boolean {
+    const fakeLabel = {
+      id: "",
+      _cls: "",
+      tags: [],
+    };
+    return isShown(state, this.field, fakeLabel);
+  }
+
+  getPoints(): Coordinates[] {
+    return [];
+  }
+
+  getSizeBytes(): number {
+    return 0;
+  }
+}

--- a/app/packages/looker/src/overlays/thumbnail.ts
+++ b/app/packages/looker/src/overlays/thumbnail.ts
@@ -53,6 +53,7 @@ export default class ThumbnailOverlay<State extends BaseState>
 
   // There is no need to support the remaining methods, as the ThumbnailOverlay
   // won't be used in a modal, and won't need to handle any interactions.
+  // However, they'll still be called, and should return empty values.
 
   containsPoint(_state: Readonly<State>): CONTAINS {
     return CONTAINS.NONE;

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -4,6 +4,7 @@
 
 import { Overlay } from "./overlays/base";
 
+import { State } from "@fiftyone/state";
 import { Schema, Stage } from "@fiftyone/utilities";
 
 // vite won't import these from fou
@@ -128,6 +129,7 @@ interface BaseConfig {
   fieldSchema: Schema;
   view: Stage[];
   dataset: string;
+  appConfig: State.DatasetAppConfig;
 }
 
 export interface FrameConfig extends BaseConfig {

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -9,9 +9,13 @@ import { useErrorHandler } from "react-error-boundary";
 import { useRecoilValue } from "recoil";
 import { mainGroupSample, selectedMediaField } from "../recoil";
 
-import { selectedSamples, SampleData } from "../recoil/atoms";
+import {
+  dataset as datasetAtom,
+  selectedSamples,
+  SampleData,
+} from "../recoil/atoms";
 import * as schemaAtoms from "../recoil/schema";
-import { datasetName } from "../recoil/selectors";
+import { datasetName as datasetNameAtom } from "../recoil/selectors";
 import { State } from "../recoil/types";
 import { getSampleSrc } from "../recoil/utils";
 import * as viewAtoms from "../recoil/view";
@@ -30,7 +34,8 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
   const activeId = isModal ? useRecoilValue(mainGroupSample)._id : null;
 
   const view = useRecoilValue(viewAtoms.view);
-  const dataset = useRecoilValue(datasetName);
+  const dataset = useRecoilValue(datasetAtom);
+  const datasetName = useRecoilValue(datasetNameAtom);
   const mediaField = useRecoilValue(selectedMediaField(isModal));
 
   const fieldSchema = useRecoilValue(
@@ -56,6 +61,7 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
       }
 
       const config: ReturnType<T["getInitialState"]>["config"] = {
+        appConfig: dataset.appConfig,
         fieldSchema: {
           ...fieldSchema,
           frames: {
@@ -73,7 +79,7 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
         src: getSampleSrc(urls[mediaField]),
         support: isClip ? sample.support : undefined,
         thumbnail,
-        dataset,
+        dataset: datasetName,
         view,
       };
 

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -15,7 +15,6 @@ import {
   SampleData,
 } from "../recoil/atoms";
 import * as schemaAtoms from "../recoil/schema";
-import { datasetName as datasetNameAtom } from "../recoil/selectors";
 import { State } from "../recoil/types";
 import { getSampleSrc } from "../recoil/utils";
 import * as viewAtoms from "../recoil/view";
@@ -35,7 +34,6 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
 
   const view = useRecoilValue(viewAtoms.view);
   const dataset = useRecoilValue(datasetAtom);
-  const datasetName = useRecoilValue(datasetNameAtom);
   const mediaField = useRecoilValue(selectedMediaField(isModal));
 
   const fieldSchema = useRecoilValue(
@@ -79,7 +77,7 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
         src: getSampleSrc(urls[mediaField]),
         support: isClip ? sample.support : undefined,
         thumbnail,
-        dataset: datasetName,
+        dataset: dataset.name,
         view,
       };
 

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -17,6 +17,7 @@ export interface SampleData {
   urls: {
     [field: string]: string;
   };
+  thumbnailsOnly: boolean;
 }
 
 export interface ModalNavigation {


### PR DESCRIPTION
Changes:
* add a ThumbnailOverlay class that just draws the thumbnail image to a canvas
* add the `thumbnails_only` parameter (though hardcoded to false for now)
* expose `dataset.app_config` to various places in the code (needed to access `grid_media_thumbnails`)

FiftyOne thumbnail PRs:
* add option to generate thumbnails for FiftyOne
* update example script to generate thumbnails
* add custom grid_thumbnail_fields field to server backend (#9)
* add custom thumbnails_only param to /samples server route (#10)
* add custom sample_id param to server route (#11)
* **show thumbnails in the grid view of the app** (#12)
* lazy load the full sample when opened in a modal (#13)

https://app.asana.com/0/0/1203821999397249/f