### PR TITLE
app: lazy load the full sample when opened in a modal

### DIFF
--- a/app/packages/core/src/components/Grid/recoil.ts
+++ b/app/packages/core/src/components/Grid/recoil.ts
@@ -43,9 +43,7 @@ export const pageParameters = selectorFamily<PageParameters, boolean>({
         extended: get(fos.extendedStages),
         zoom: get(fos.isPatchesView) && get(fos.cropToContent(modal)),
         slice: get(groupSlice(false)),
-        // TODO: change this to !modal when lazy loading samples on click is
-        // implemented
-        thumbnails_only: false,
+        thumbnails_only: !modal,
       };
     },
 });

--- a/app/packages/core/src/components/Grid/useExpandSample.ts
+++ b/app/packages/core/src/components/Grid/useExpandSample.ts
@@ -1,47 +1,112 @@
-import { FlashlightConfig } from "@fiftyone/flashlight";
-import { useCallback } from "react";
+import { Snapshot, useRecoilCallback } from "recoil";
 
+import { ItemIndexMap } from "@fiftyone/flashlight/src/state";
 import * as fos from "@fiftyone/state";
+import { getFetchFunction } from "@fiftyone/utilities";
+
+import { pageParameters } from "./recoil";
+
+interface SamplesResponse {
+  results: Array<{
+    sample: fos.AppSample & { frame_number?: number };
+    aspect_ratio: number;
+    frame_rate?: number;
+    urls: Array<{ field: string; url: string }>;
+    thumbnails_only: boolean;
+  }>;
+}
+
+/**
+ * Returns a full sample by id, querying from the backend if necessary.
+ *
+ * Throws if the provided sampleId does not exist in the store.
+ */
+async function getFullSample<T extends fos.Lookers>(
+  store: fos.LookerStore<T>,
+  snapshot: Snapshot,
+  sampleId: string
+): Promise<fos.SampleData | null> {
+  const existingSample = store.samples.get(sampleId);
+
+  if (!existingSample) {
+    return null;
+  }
+
+  if (!existingSample.thumbnailsOnly) {
+    return existingSample;
+  } else {
+    // Query for the full sample from the backend
+    const { zoom, ...params } = await snapshot.getPromise(
+      pageParameters(/* modal= */ true)
+    );
+
+    const { results } = (await getFetchFunction()("POST", "/samples", {
+      ...params,
+      sample_id: sampleId,
+    })) as SamplesResponse;
+    const result = results[0];
+
+    const newSample: fos.SampleData = {
+      sample: result.sample,
+      aspectRatio: result.aspect_ratio,
+      frameRate: result.frame_rate,
+      frameNumber: result.sample.frame_number,
+      urls: Object.fromEntries(
+        result.urls.map(({ field, url }) => [field, url])
+      ),
+      thumbnailsOnly: false,
+    };
+
+    // Save the new sample in the global store
+    store.samples.set(result.sample._id, newSample);
+    return newSample;
+  }
+}
 
 export default <T extends fos.Lookers>(store: fos.LookerStore<T>) => {
   const expandSample = fos.useExpandSample();
   const setSample = fos.useSetExpandedSample(false);
   const clear = fos.useClearModal();
 
-  return useCallback<
-    (
-      ...args: Parameters<NonNullable<FlashlightConfig<number>["onItemClick"]>>
-    ) => void
-  >(
-    (next, sampleId, itemIndexMap) => {
-      const clickedIndex = itemIndexMap[sampleId];
+  return useRecoilCallback(
+    ({ snapshot }) =>
+      async (
+        next: () => Promise<void>,
+        sampleId: string,
+        itemIndexMap: ItemIndexMap
+      ): Promise<void> => {
+        const clickedIndex = itemIndexMap[sampleId];
 
-      const getIndex = (index: number) => {
-        const id = store.indices.get(index);
+        const getIndex = (index: number) => {
+          const id = store.indices.get(index);
 
-        const promise = id ? Promise.resolve(id) : next();
+          const promise = id ? Promise.resolve(id) : next();
 
-        promise
-          ? promise.then(() => {
-              const id = store.indices.get(index);
+          promise
+            ? promise.then(async () => {
+                const sampleId = store.indices.get(index);
 
-              if (!id) {
-                throw new Error("unable to paginate to next sample");
-              }
+                if (!sampleId) {
+                  throw new Error("unable to paginate to next sample");
+                }
 
-              setSample(store.samples.get(id), { index, getIndex });
-            })
-          : clear();
-      };
+                const sample = await getFullSample(store, snapshot, sampleId);
+                if (!sample) {
+                  throw new Error(`sample does not exist (id=${sampleId})`);
+                }
 
-      const sample = store.samples.get(sampleId);
+                setSample(sample, { index, getIndex });
+              })
+            : clear();
+        };
 
-      if (!sample) {
-        throw new Error("sample not found");
-      }
+        const sample = await getFullSample(store, snapshot, sampleId);
+        if (!sample) {
+          throw new Error(`sample does not exist (id=${sampleId})`);
+        }
 
-      expandSample(sample, { index: clickedIndex, getIndex });
-    },
+        expandSample(sample, { index: clickedIndex, getIndex });
+      },
     [store]
   );
 };

--- a/app/packages/core/src/components/Grid/useExpandSample.ts
+++ b/app/packages/core/src/components/Grid/useExpandSample.ts
@@ -6,6 +6,9 @@ import { getFetchFunction } from "@fiftyone/utilities";
 
 import { pageParameters } from "./recoil";
 
+/**
+ * Pyton object returned from the `/samples` API.
+ */
 interface SamplesResponse {
   results: Array<{
     sample: fos.AppSample & { frame_number?: number };
@@ -77,6 +80,7 @@ export default <T extends fos.Lookers>(store: fos.LookerStore<T>) => {
       ): Promise<void> => {
         const clickedIndex = itemIndexMap[sampleId];
 
+        // getIndex is called when clicking the left/right arrows in the modal
         const getIndex = (index: number) => {
           const id = store.indices.get(index);
 


### PR DESCRIPTION
Last PR in the sequence! (If everything works)

* Only load thumbnails in the initial grid view
* Load the full sample when a sample is clicked on
* Load the full sample when a sample is navigated to (the left or right arrows in the modal)

See demo video in the linked task.
* There is a delay when moving left or right between samples in the model due to querying the full sample
  * might be able to eliminate this by using the sample with thumbnails only first, then switching to the full sample
* Segmentation colors don't match because of the random color_pool ordering atm


FiftyOne thumbnail PRs:
* add option to generate thumbnails for FiftyOne
* update example script to generate thumbnails
* add custom grid_thumbnail_fields field to server backend (#9)
* add custom thumbnails_only param to /samples server route (#10)
* add custom sample_id param to server route (#11)
* **show thumbnails in the grid view of the app** (#12)
* lazy load the full sample when opened in a modal (#13)

https://app.asana.com/0/0/1203821999397249/f