### PR TITLE
app: match segmentation coloring to color_pool

### DIFF
--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -162,7 +162,7 @@ export const colorPool = atom<string[]>({
 
 export const colorSeed = atomFamily<number, boolean>({
   key: "colorSeed",
-  default: 1,
+  default: 0,
 });
 
 export const appTeamsIsOpen = atom({

--- a/app/packages/utilities/src/color.ts
+++ b/app/packages/utilities/src/color.ts
@@ -186,7 +186,13 @@ export const createColorGenerator = (() => {
         return map[val];
       }
 
-      map[val] = colorPool[i % colorPool.length];
+      if (Number.isInteger(val)) {
+        // If the value is an integer, index directly into the colormap
+        map[val] = colorPool[val % colorPool.length];
+      } else {
+        // Otherwise use the counter and iterate through the colors
+        map[val] = colorPool[i % colorPool.length];
+      }
       i++;
       return map[val];
     };


### PR DESCRIPTION
* Initialize `colorSeed` to 0 to avoid randomly shuffling the colors
* Index directly into `colorPool` when the lookup value is an integer (instead of incrementing a counter based on lookup order)

Thumbnail colormap syncs up with the FiftyOne app.

Thumbnail:
![2023-02-13_14-49-19](https://user-images.githubusercontent.com/3599407/218592131-93da78cb-d050-4974-80dc-a0e7c522c7da.png)

Modal:
![2023-02-13_14-49-32](https://user-images.githubusercontent.com/3599407/218592130-3dceaa66-979a-4748-b0b5-9bd3948073c4.png)

https://app.asana.com/0/1203288718560208/1203912493499257/f