### PR TITLE
app: unlink frontend sessions

### DIFF
--- a/app/packages/app/src/index.tsx
+++ b/app/packages/app/src/index.tsx
@@ -130,7 +130,7 @@ const App: React.FC = ({}) => {
       {
         initializer: getDatasetName(contextRef.current),
         subscription,
-        events: [Events.DEACTIVATE_NOTEBOOK_CELL, Events.STATE_UPDATE],
+        events: [],
       }
     );
 


### PR DESCRIPTION
Unlink frontend sessions. State updates are sent from the server via the `/events` endpoint, which an open connection using Server-Sent Events.

Note: it'll still retrieve state of whoever modified it last when you refresh, but otherwise it doesn't refresh the page when someone else changes the search/filter or dataset.

https://user-images.githubusercontent.com/3599407/222297446-e55e3c9c-09ad-482b-ad96-7702d1d1cbdf.mp4


https://app.asana.com/0/1203968572964807/1203576734637210/f