### PR TITLE
server: add `colors` field to dataset app_config

### DIFF
--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -30,6 +30,7 @@ const DatasetQuery = graphql`
           name
         }
         gridThumbnailFields
+        colors
       }
       sampleFields {
         ftype

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b381c50a6a746c1c62f2054176fef9c>>
+ * @generated SignedSource<<76e419e5b18d426a3b9f9ffca62dcf8e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type DatasetQuery$variables = {
 export type DatasetQuery$data = {
   readonly dataset: {
     readonly appConfig: {
+      readonly colors: object | null;
       readonly gridMediaField: string | null;
       readonly gridThumbnailFields: object | null;
       readonly mediaFields: ReadonlyArray<string>;
@@ -365,6 +366,13 @@ v17 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "colors",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "sidebarMode",
             "storageKey": null
           }
@@ -604,16 +612,16 @@ return {
     "selections": (v17/*: any*/)
   },
   "params": {
-    "cacheID": "3fb49422cab6144e41e2c7915f48fdb0",
+    "cacheID": "da82f3fcf58ba18e3e9842941f7dfdf0",
     "id": null,
     "metadata": {},
     "name": "DatasetQuery",
     "operationKind": "query",
-    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      gridThumbnailFields\n      sidebarMode\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    info\n  }\n}\n"
+    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      gridThumbnailFields\n      colors\n      sidebarMode\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    info\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cf9241bdb7344bc90d22665114d8d4ba";
+(node as any).hash = "895f21317984f32725c2420775b7f14f";
 
 export default node;

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -3,13 +3,7 @@ input Aggregate {
   histogramValues: HistogramValues = null
 }
 
-union AggregateResult =
-    BooleanAggregation
-  | DataAggregation
-  | IntAggregation
-  | FloatAggregation
-  | RootAggregation
-  | StringAggregation
+union AggregateResult = BooleanAggregation | DataAggregation | IntAggregation | FloatAggregation | RootAggregation | StringAggregation
 
 interface Aggregation {
   path: String!
@@ -31,13 +25,7 @@ input AggregationForm {
   view: BSONArray!
 }
 
-union AggregationResponses =
-    BoolCountValuesResponse
-  | IntCountValuesResponse
-  | StrCountValuesResponse
-  | DatetimeHistogramValuesResponse
-  | FloatHistogramValuesResponse
-  | IntHistogramValuesResponse
+union AggregationResponses = BoolCountValuesResponse | IntCountValuesResponse | StrCountValuesResponse | DatetimeHistogramValuesResponse | FloatHistogramValuesResponse | IntHistogramValuesResponse
 
 type AppConfig {
   colorBy: ColorBy!
@@ -143,6 +131,7 @@ type DatasetAppConfig {
   modalMediaField: String
   gridMediaField: String
   gridThumbnailFields: JSON
+  colors: JSON
 }
 
 type DatasetStrConnection {
@@ -266,35 +255,12 @@ type MediaURL {
 
 type Mutation {
   setDataset(subscription: String!, session: String, name: String): Boolean!
-  setSidebarGroups(
-    dataset: String!
-    stages: BSONArray!
-    sidebarGroups: [SidebarGroupInput!]!
-  ): Boolean!
-  setSelected(
-    subscription: String!
-    session: String
-    selected: [String!]!
-  ): Boolean!
-  setSelectedLabels(
-    subscription: String!
-    session: String
-    selectedLabels: [SelectedLabel!]!
-  ): Boolean!
-  setView(
-    subscription: String!
-    session: String
-    view: BSONArray!
-    dataset: String!
-    form: StateForm
-  ): ViewResponse!
+  setSidebarGroups(dataset: String!, stages: BSONArray!, sidebarGroups: [SidebarGroupInput!]!): Boolean!
+  setSelected(subscription: String!, session: String, selected: [String!]!): Boolean!
+  setSelectedLabels(subscription: String!, session: String, selectedLabels: [SelectedLabel!]!): Boolean!
+  setView(subscription: String!, session: String, view: BSONArray!, dataset: String!, form: StateForm): ViewResponse!
   storeTeamsSubmission: Boolean!
-  setGroupSlice(
-    subscription: String!
-    session: String
-    view: BSONArray!
-    slice: String!
-  ): Dataset!
+  setGroupSlice(subscription: String!, session: String, view: BSONArray!, slice: String!): Dataset!
 }
 
 type NamedKeypointSkeleton {
@@ -315,16 +281,8 @@ type PointCloudSample implements Sample {
 }
 
 type Query {
-  aggregate(
-    datasetName: String!
-    view: BSONArray!
-    aggregations: [Aggregate!]!
-  ): [AggregationResponses!]!
-  datasets(
-    search: String
-    first: Int = 200
-    after: String = null
-  ): DatasetStrConnection!
+  aggregate(datasetName: String!, view: BSONArray!, aggregations: [Aggregate!]!): [AggregationResponses!]!
+  datasets(search: String, first: Int = 200, after: String = null): DatasetStrConnection!
   aggregations(form: AggregationForm!): [AggregateResult!]!
   colorscale: [[Int!]!]
   config: AppConfig!
@@ -332,13 +290,7 @@ type Query {
   dev: Boolean!
   doNotTrack: Boolean!
   dataset(name: String!, view: BSONArray): Dataset
-  samples(
-    dataset: String!
-    view: BSONArray!
-    first: Int = 20
-    after: String = null
-    filter: SampleFilter = null
-  ): SampleItemStrConnection!
+  samples(dataset: String!, view: BSONArray!, first: Int = 20, after: String = null, filter: SampleFilter = null): SampleItemStrConnection!
   sample(dataset: String!, view: BSONArray!, filter: SampleFilter!): SampleItem
   teamsSubmission: Boolean!
   uid: String!

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -318,6 +318,10 @@ class DatasetAppConfig(EmbeddedDocument):
         grid_thumbnail_fields ({}): an optional dict mapping sample fields to
             sample thumbnail fields (where the thumbnail fields contain string
             paths to the thumbnail images on disk)
+        colors ({}): an optional dict mapping sample fields to per-field color
+            configs. Per-field color configs can contain the keys `colormap`,
+            `wrap`, `ignore_color`. For details, see `State.FieldColoring` in
+            `app/packages/state/src/recoil/types.ts`.
     """
 
     # strict=False lets this class ignore unknown fields from other versions
@@ -332,6 +336,7 @@ class DatasetAppConfig(EmbeddedDocument):
     )
     plugins = DictField()
     grid_thumbnail_fields = DictField()
+    colors = DictField()
 
     @staticmethod
     def default_sidebar_groups(sample_collection):

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -141,6 +141,7 @@ class DatasetAppConfig:
     modal_media_field: t.Optional[str] = gql.field(default="filepath")
     grid_media_field: t.Optional[str] = "filepath"
     grid_thumbnail_fields: t.Optional[JSON]
+    colors: t.Optional[JSON]
 
 
 @gql.type


### PR DESCRIPTION
Setting up for finer color configuration for semseg and heatmaps. This _should_ be the only server-side change needed - `colors` is a free-form JSON and we can accommodate any options we want either on the Jupyter or App side.

https://compoundeye.slab.com/posts/fifty-one-colormaps-txmnhr1h

* `schema.graphql` generated via `/src/app$ yarn run gen:schema`
* `DatasetQuery.graphql.ts` generated via `/src/app/packages/core$ yarn run compile`

https://app.asana.com/0/1203968572964807/1203912493499259/f
https://app.asana.com/0/1203968572964807/1203576734637202/f
https://app.asana.com/0/1203968572964807/1203912493499255/f