### PR TITLE
env: modify Dockerfile for development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 *
 !Dockerfile
 !dist
+!install.bash
+!requirements.txt
+!requirements/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$(dirname $(realpath $0))
+
+docker build -t ce_fiftyone_dev .

--- a/install.bash
+++ b/install.bash
@@ -31,7 +31,9 @@ SOURCE_ETA_INSTALL=false
 SCRATCH_MONGODB_INSTALL=false
 BUILD_APP=true
 VOXEL51_INSTALL=false
-while getopts "hdempv" FLAG; do
+# Only install Python dependencies, skip git setup
+DEPS_ONLY=false
+while getopts "hdempvo" FLAG; do
     case "${FLAG}" in
         h) SHOW_HELP=true ;;
         d) DEV_INSTALL=true ;;
@@ -39,6 +41,7 @@ while getopts "hdempv" FLAG; do
         m) SCRATCH_MONGODB_INSTALL=true ;;
         v) VOXEL51_INSTALL=true ;;
         p) BUILD_APP=false ;;
+        o) DEPS_ONLY=true ;;
         *) usage ;;
     esac
 done
@@ -116,11 +119,15 @@ echo "***** INSTALLING FIFTYONE *****"
 if [ ${DEV_INSTALL} = true ] || [ ${VOXEL51_INSTALL} = true ]; then
     echo "Performing dev install"
     pip install -r requirements/dev.txt
-    pre-commit install
-    pip install -e .
+    if [ ${DEPS_ONLY} = false ]; then
+        pre-commit install
+        pip install -e .
+    fi
 else
     pip install -r requirements.txt
-    pip install .
+    if [ ${DEPS_ONLY} = false ]; then
+        pip install .
+    fi
 fi
 
 if [ ${SOURCE_ETA_INSTALL} = true ]; then
@@ -143,21 +150,21 @@ if [ ${SOURCE_ETA_INSTALL} = true ]; then
 fi
 
 # Do this last since `source` can exit Python virtual environments
+echo "***** INSTALLING FIFTYONE-APP *****"
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+nvm install ${NODE_VERSION}
+nvm use ${NODE_VERSION}
+npm -g install yarn
+if [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+elif [ -f ~/.bash_profile ]; then
+    source ~/.bash_profile
+else
+    echo "WARNING: unable to locate a bash profile to 'source'; you may need to start a new shell"
+fi
 if [ ${BUILD_APP} = true ]; then
-    echo "***** INSTALLING FIFTYONE-APP *****"
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
-    export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-    nvm install ${NODE_VERSION}
-    nvm use ${NODE_VERSION}
-    npm -g install yarn
-    if [ -f ~/.bashrc ]; then
-        source ~/.bashrc
-    elif [ -f ~/.bash_profile ]; then
-        source ~/.bash_profile
-    else
-        echo "WARNING: unable to locate a bash profile to 'source'; you may need to start a new shell"
-    fi
     cd app
     echo "Building the App. This will take a minute or two..."
     yarn install > /dev/null 2>&1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,7 +9,7 @@ httpx==0.23.0
 hypercorn==0.13.2
 Jinja2==3.0.3
 kaleido==0.2.1
-matplotlib==3.5.2
+matplotlib==3.7.1
 mongoengine==0.24.2
 motor>=2.3
 ndjson==0.3.1

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$(dirname $(realpath $0))
+FIFTYONE_SRC=$DIR
+PORT_OPTS=${PORT_OPTS:--p 5151:5151 -p 5173:5173}
+
+docker run \
+    -it \
+    --mount "type=bind,source=$FIFTYONE_SRC,target=/src" \
+    --mount "type=bind,source=/,target=/host" \
+    -u "$(id -u $USER):$(id -g $USER)" \
+    ${PORT_OPTS} \
+    ce_fiftyone_dev bash


### PR DESCRIPTION
Modify Dockerfile for developing FiftyOne. Helps to run multiple instances at once, easily reset instances, and avoid IPC/port conflicts.
* adds `run.sh` and `build.sh` for easy building
* updates `matplotlib` to match internal versions
* adds `PORT_OPTS` to configure container-to-host mapping (network is in bridge mode)