### PR TITLE
app: handle per-field colors

### DIFF
--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -19,6 +19,9 @@ export interface Coloring {
   maskTargets: {
     [field: string]: MaskTargets;
   };
+  colors: {
+    [field: string]: State.FieldColoring;
+  };
   points: boolean;
   targets: string[];
 }
@@ -289,6 +292,7 @@ const DEFAULT_BASE_OPTIONS: BaseOptions = {
     maskTargets: {},
     defaultMaskTargets: null,
     targets: ["#000000"],
+    colors: {},
   },
   smoothMasks: true,
   hasNext: false,

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -28,6 +28,7 @@ export const coloring = selectorFamily<Coloring, boolean>({
         targets: new Array(pool.length)
           .fill(0)
           .map((_, i) => getColor(pool, seed, i)),
+        colors: get(selectors.colors),
       };
     },
   cachePolicy_UNSTABLE: {

--- a/app/packages/state/src/recoil/selectors.ts
+++ b/app/packages/state/src/recoil/selectors.ts
@@ -111,6 +111,16 @@ export const targets = selector({
   },
 });
 
+export const colors = selector({
+  key: "colors",
+  get: ({ get }) => {
+    return get(atoms.dataset).appConfig.colors || {};
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: "most-recent",
+  },
+});
+
 export const getSkeleton = selector<(field: string) => KeypointSkeleton | null>(
   {
     key: "getSkeleton",

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -1,4 +1,4 @@
-import { StrictField } from "@fiftyone/utilities";
+import { RGB, RGBA, StrictField } from "@fiftyone/utilities";
 
 export namespace State {
   export type MediaType = "image" | "group" | "point_cloud" | "video";
@@ -83,6 +83,11 @@ export namespace State {
     paths: string[];
   }
 
+  export interface FieldColoring {
+    colorMap: RGB[];
+    colorPool: RGB[];
+  }
+
   export interface DatasetAppConfig {
     gridMediaField?: string;
     modalMediaField?: string;
@@ -91,6 +96,7 @@ export namespace State {
     sidebarGroups?: SidebarGroup[];
     sidebarMode?: "all" | "best" | "fast";
     gridThumbnailFields?: { [field: string]: string };
+    colors?: { [field: string]: FieldColoring };
   }
   export interface Dataset {
     id: string;

--- a/app/packages/utilities/src/color.ts
+++ b/app/packages/utilities/src/color.ts
@@ -30,8 +30,18 @@ export const getRGB = (color: string): RGB => {
   return [r, g, b];
 };
 
-export const get32BitColor = (color: string | RGB, alpha: number = 1) => {
-  alpha = Math.round(alpha * 255);
+export const get32BitColor = (color: string | RGB | RGBA, alpha?: number) => {
+  if (Array.isArray(color) && color.length === 4 && alpha == null) {
+    // Use the input color's alpha if the alpha paramter is unspecified
+    alpha = color[3];
+  } else if (alpha == null) {
+    // Default alpha
+    alpha = 255;
+  } else {
+    // Convert input alpha from [0, 1] to [0, 255]
+    alpha = Math.round(alpha * 255);
+  }
+
   const key = `${color}${alpha}`;
   if (key in bitColorCache) {
     return bitColorCache[key];


### PR DESCRIPTION
Render per-field colors on the frontend.

Example using red-green-blue colors for semseg:
![2023-03-14_14-05-34](https://user-images.githubusercontent.com/3599407/225136201-9989e87e-1254-41be-9f2d-bcbb0a463a76.png)

Example using `turbo` colormap for heatmaps:
![2023-03-14_14-05-26](https://user-images.githubusercontent.com/3599407/225136261-f816594b-77ab-4004-830d-b8434d645f6e.png)

https://app.asana.com/0/1203968572964807/1203576734637202/f
https://app.asana.com/0/1203968572964807/1203912493499255/f