### PR TITLE
app: support ignored values and colors

### DIFF
--- a/app/packages/looker/src/worker.ts
+++ b/app/packages/looker/src/worker.ts
@@ -408,8 +408,6 @@ const UPDATE_LABEL = {
       return;
     }
 
-    const fieldColors = coloring.colors[field] ?? {};
-    const colormap = fieldColors["color_map"] ?? coloring.scale;
     const overlay = new Uint32Array(label.map.image);
     const targets = new ARRAY_TYPES[label.map.data.arrayType](
       label.map.data.buffer
@@ -420,14 +418,18 @@ const UPDATE_LABEL = {
       ? [0, 1]
       : [0, 255];
 
-    const color = await requestColor(coloring.pool, coloring.seed, field);
+    const fieldColors = coloring.colors[field] ?? {};
+    const colormap = fieldColors["color_map"] ?? coloring.scale;
+    const ignoreValue = label.ignore ?? NaN;
+    const ignoreColor = fieldColors["ignore_color"] ?? [0, 0, 0, 0];
 
+    const color = await requestColor(coloring.pool, coloring.seed, field);
     const getColor =
       coloring.by === "label"
         ? // If coloring by label, lookup the index from the colormap
           (value) => {
-            if (isNaN(value)) {
-              return 0;
+            if (isNaN(value) || value === ignoreValue) {
+              return get32BitColor(ignoreColor);
             }
 
             const index = clamp(


### PR DESCRIPTION
Two examples where the heatmap is opaque but ignore color is half-transparent:
![2023-03-14_15-17-15](https://user-images.githubusercontent.com/3599407/225155028-60e71dc7-6c32-43ac-acde-4611b6fb7d48.png)
![2023-03-14_15-17-07](https://user-images.githubusercontent.com/3599407/225155029-0f16e394-f80b-410a-a31c-8854939a1ce8.png)

https://app.asana.com/0/1203968572964807/1203912493499259/f