### PR TITLE
app: show full field values in sidebar

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -31,7 +31,8 @@ const ScalarDiv = styled.div`
     font-weight: bold;
     padding: 0 3px;
     overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: break-word;
+    text-overflow: clip;
   }
 `;
 
@@ -221,7 +222,15 @@ const Loadable = ({ path }: { path: string }) => {
   const timeZone = useRecoilValue(fos.timeZone);
   const formatted = format({ ftype, value, timeZone });
 
-  return <div style={none ? { color } : {}}>{none ? "None" : formatted}</div>;
+  return (
+    <div
+      style={none ? { color } : {}}
+      // show the full text on hover
+      title={value != null ? value.toString() : undefined}
+    >
+      {none ? "None" : formatted}
+    </div>
+  );
 };
 
 const useData = <T extends unknown>(path: string): T => {


### PR DESCRIPTION
Show the full value of fields in the sidebar. Normally you'd have to open the JSON view to see it, but the JSON view is cluttered by the base64 encoded heatmap/segmentation masks.

![2023-03-29_17-06-22](https://user-images.githubusercontent.com/3599407/228891522-8eb524e8-0abf-4804-8c2e-acd89b6bb196.png)
