### PR TITLE
app: make the JSON view scrollable

### DIFF
--- a/app/packages/components/src/components/JSONPanel/json.module.css
+++ b/app/packages/components/src/components/JSONPanel/json.module.css
@@ -10,7 +10,11 @@
 }
 
 .lookerJSONPanel pre {
+  width: 100%;
+  height: 100%;
+  padding-right: 0.5rem;
   font-weight: normal;
+  overflow-y: scroll;
 }
 
 .lookerCloseJSON {

--- a/app/packages/components/src/components/JSONPanel/panel.module.css
+++ b/app/packages/components/src/components/JSONPanel/panel.module.css
@@ -41,6 +41,7 @@
 }
 
 .lookerPanelVerticalContainer {
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
You can view the JSON for each sample in the pop up modal. However because the heatmap is stored in the sample, it makes the panel too wide.

Before:
![2023-03-30_16-40-30](https://user-images.githubusercontent.com/3599407/228989049-b7c82a7a-8c54-4eff-971d-9384edfe79e4.png)

After:
![2023-03-30_16-47-09](https://user-images.githubusercontent.com/3599407/228989053-2b2ece9c-1a64-4b0b-9b26-d944a2f58c3e.png)
