### PR TITLE
env: use RUN --mount during build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
-*
-!Dockerfile
-!dist
-!install.bash
-!requirements.txt
-!requirements/
+# Directories to ignore from the Docker build context
+# Calling COPY or RUN --mount=type=bind is slow if the build context is large.
+.git/
+app/.yarn/
+build/
+dist/
+fiftyone.egg-info/
+**/node_modules/
+**/__pycache__/

--- a/install.bash
+++ b/install.bash
@@ -32,7 +32,6 @@ SCRATCH_MONGODB_INSTALL=false
 BUILD_APP=true
 VOXEL51_INSTALL=false
 # Only install Python dependencies, skip git setup
-DEPS_ONLY=false
 while getopts "hdempvo" FLAG; do
     case "${FLAG}" in
         h) SHOW_HELP=true ;;
@@ -41,7 +40,6 @@ while getopts "hdempvo" FLAG; do
         m) SCRATCH_MONGODB_INSTALL=true ;;
         v) VOXEL51_INSTALL=true ;;
         p) BUILD_APP=false ;;
-        o) DEPS_ONLY=true ;;
         *) usage ;;
     esac
 done
@@ -106,15 +104,11 @@ echo "***** INSTALLING FIFTYONE *****"
 if [ ${DEV_INSTALL} = true ] || [ ${VOXEL51_INSTALL} = true ]; then
     echo "Performing dev install"
     pip install -r requirements/dev.txt
-    if [ ${DEPS_ONLY} = false ]; then
-        pre-commit install
-        pip install -e .
-    fi
+    pre-commit install
+    pip install -e .
 else
     pip install -r requirements.txt
-    if [ ${DEPS_ONLY} = false ]; then
-        pip install .
-    fi
+    pip install .
 fi
 
 if [ ${SOURCE_ETA_INSTALL} = true ]; then

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ PORT_OPTS=${PORT_OPTS:--p 5151:5151 -p 5173:5173}
 
 docker run \
     -it \
-    --mount "type=bind,source=$FIFTYONE_SRC,target=/src" \
+    --mount "type=bind,source=$FIFTYONE_SRC,target=/src51" \
     --mount "type=bind,source=/,target=/host" \
     -u "$(id -u $USER):$(id -g $USER)" \
     ${PORT_OPTS} \


### PR DESCRIPTION
Use the `RUN --mount` option during docker build to install `fiftyone` as a local package during build.

https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#mount-types