### PR TITLE
app: fix handling of 0s in heatmaps and segmentations

### DIFF
--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -145,14 +145,12 @@ export const PainterFactory = (requestColor) => ({
 
     // these for loops must be fast. no "in" or "of" syntax
     for (let i = 0; i < overlay.length; i++) {
-      if (targets[i] !== 0) {
-        if (mapData.channels > 2) {
-          overlay[i] = getColor(
-            getRgbFromMaskData(targets, mapData.channels, i)[0]
-          );
-        } else {
-          overlay[i] = getColor(targets[i]);
-        }
+      if (mapData.channels > 2) {
+        overlay[i] = getColor(
+          getRgbFromMaskData(targets, mapData.channels, i)[0]
+        );
+      } else {
+        overlay[i] = getColor(targets[i]);
       }
     }
   },
@@ -243,16 +241,14 @@ export const PainterFactory = (requestColor) => ({
 
       // these for loops must be fast. no "in" or "of" syntax
       for (let i = 0; i < overlay.length; i++) {
-        if (targets[i] !== 0) {
-          if (
-            !(targets[i] in maskTargets) &&
-            !isMaskTargetsEmpty &&
-            !isRgbMaskTargets_
-          ) {
-            targets[i] = 0;
-          } else {
-            overlay[i] = color ? color : getColor(targets[i]);
-          }
+        if (
+          !(targets[i] in maskTargets) &&
+          !isMaskTargetsEmpty &&
+          !isRgbMaskTargets_
+        ) {
+          targets[i] = 0;
+        } else {
+          overlay[i] = color ? color : getColor(targets[i]);
         }
       }
     }


### PR DESCRIPTION
Zeroes no longer appear as transparent.

I left out this change when upgrading to the latest FiftyOne: https://github.com/compound-eye/fiftyone/pull/6/files#diff-075b58325fce2abadfed421b7b78f9c6b33dfe6ec1f1601b32580ad4270eaf6cL461

Before:
![image](https://github.com/compound-eye/fiftyone/assets/3599407/79c56450-0caf-40ee-af29-f3b73e813f9d)

After:
![2023-10-16_08-00-49](https://github.com/compound-eye/fiftyone/assets/3599407/943f2db5-5b10-462b-ac50-f91ee51c3096)

