### PR TITLE
app: disable thumbnails on group looker

### DIFF
--- a/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
@@ -48,6 +48,7 @@ const pageParams = selector({
           slices: get(groupCarouselSlices),
         },
       },
+      thumbnailsOnly: false,
     };
     return (page: number, pageSize: number) => {
       return {
@@ -74,7 +75,7 @@ const Column: React.FC = () => {
 
   const createLooker = fos.useCreateLooker(
     false,
-    true,
+    false,
     {
       ...opts,
       thumbnailTitle: (sample) => get(sample, groupField).name,

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -248,6 +248,7 @@ export const groupSamples = graphQLSelectorFamily<
           },
         },
         paginationData,
+        thumbnailsOnly: false,
       };
     },
   mapResponse: (data: ResponseFrom<foq.paginateSamplesQuery>) => {


### PR DESCRIPTION
Grouped samples open up in a different overlay than normal samples, and had the `thumbnail` flag incorrectly set. As a result none of the labels loaded, and trying to show any of them causes an error.