### PR TITLE
app: don't crash if thumbnail is missing

### DIFF
--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -69,13 +69,15 @@ export const loadOverlays = <State extends BaseState>(
     for (const [fieldName, thumbnailFieldName] of Object.entries(
       gridThumbnailFields
     ) as ReadonlyArray<[string, string]>) {
-      overlays.push(
-        new ThumbnailOverlay(
-          fieldName,
-          thumbnailFieldName,
-          sample[thumbnailFieldName]
-        )
-      );
+      if (sample[thumbnailFieldName] != null) {
+        overlays.push(
+          new ThumbnailOverlay(
+            fieldName,
+            thumbnailFieldName,
+            sample[thumbnailFieldName]
+          )
+        );
+      }
     }
   }
 


### PR DESCRIPTION
If a thumbnail doesn't exist (because the label doesn't exist), then showing the thumbnail overlay will throw an error:
```
Error: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The HTMLImageElement provided is in the 'broken' state.
```

Example: I removed the `stereo` label on the 2nd sample, and `gt` label on the 3rd sample:
![2023-12-12_10-37-06](https://github.com/compound-eye/fiftyone/assets/3599407/7752aaf4-d7c7-4535-b1f7-da5af68ff08e)
![2023-12-12_10-37-20](https://github.com/compound-eye/fiftyone/assets/3599407/cb6f85e8-2f63-4ef3-8203-ac740dd51d4d)
